### PR TITLE
:ambulance: bug(deps): allow newer version of angularjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,11 +24,11 @@
   "dependencies": {
     "jquery": "~2.1.3",
     "lodash": "~3.3.0",
-    "angular": "~1.3.15",
-    "angular-sanitize": "~1.3.15"
+    "angular": "1.3.15 - 1.5.x",
+    "angular-sanitize": "1.3.15 - 1.5.x"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.15",
-    "angular-scenario": "~1.3.15"
+    "angular-mocks": "1.3.15 - 1.5.x",
+    "angular-scenario": "1.3.15 - 1.5.x"
   }
 }


### PR DESCRIPTION
The deps should allow newer version of angular js, to avoid prompt when `bower install' in other components that have deps to this one